### PR TITLE
Eliminar ruta de Managment del módulo de enrutamiento

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -32,11 +32,6 @@ const routes: Routes = [
       import('./pages/perfil/perfil.module').then((m) => m.PerfilModule),
   },
   {
-    path: 'managment',
-    loadChildren: () =>
-      import('./pages/managment/managment.module').then((m) => m.ManagmentModule),
-  },
-  {
     path: '**',
     redirectTo: '',
   },


### PR DESCRIPTION
Se elimino el codigo que enruta al Managment de plataforma dicta desde el app-routing