### PR TITLE
Implementación de HttpOnly (Issue #8)

### DIFF
--- a/src/app/core/security/jwt.interceptor.ts
+++ b/src/app/core/security/jwt.interceptor.ts
@@ -9,28 +9,18 @@ import { Router } from '@angular/router';
 export class JwtInterceptor implements HttpInterceptor {
 
   constructor(
-    private tokenStorage: TokenStorageService,
     private router: Router
   ) {}
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    const token = this.tokenStorage.getToken();
-
-    let authReq = req;
-
-    if (token) {
-      authReq = req.clone({
-        setHeaders: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-    }
+    const authReq = req.clone({
+      withCredentials: true
+    })
 
     return next.handle(authReq).pipe(
       catchError((error: HttpErrorResponse) => {
-        const isLoginRequest = req.url.includes('/auth/login');
-        if (error.status === 401 && !isLoginRequest) {
-          this.tokenStorage.clearToken();
+        const isAuthEndPoint = req.url.includes('/auth/login');
+        if (error.status === 401 && !isAuthEndPoint) {
           this.router.navigate(['/login']);
         }
         return throwError(() => error);

--- a/src/app/pages/auth/services/auth.service.ts
+++ b/src/app/pages/auth/services/auth.service.ts
@@ -1,38 +1,30 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router';
-import { TokenStorageService } from 'src/app/core/security/token-storage.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
 
-  private loggedInSubject = new BehaviorSubject<boolean>(this.hasToken());
+  private loggedInSubject = new BehaviorSubject<boolean>(false);
   public isLoggedIn$ = this.loggedInSubject.asObservable();
 
   constructor(
-    private tokenStorage: TokenStorageService,
     private router: Router
   ) {}
 
-  private hasToken(): boolean {
-    return !!this.tokenStorage.getToken();
-  }
-
-  login(token: string): void {
-    this.tokenStorage.setToken(token);
+  login(): void {
     this.loggedInSubject.next(true);
   }
 
   logout(): void {
-    this.tokenStorage.clearToken();
     this.loggedInSubject.next(false);
     this.router.navigate(['/']);
   }
 
   isLoggedIn(): boolean {
-    return this.hasToken();
+    return this.loggedInSubject.value;
   }
 
   getUserImg(): string {

--- a/src/app/shared/patterns/facade/managment/login-facade.ts
+++ b/src/app/shared/patterns/facade/managment/login-facade.ts
@@ -29,9 +29,9 @@ export class LoginFacade {
       .iniciarSesion(login)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (response: LoginResponse) => {
-          this.authService.login(response.accessToken);
-          this.login$.next(response);
+        next: () => {
+          this.authService.login();
+          this.login$.next(null);
 
           this.messageService.add({
             key: 'global',


### PR DESCRIPTION
**Cambios principales:** 
- Se eliminó el manejo del token JWT en el front, ahora se maneja mediante las cookies.
- Ya no tiene acceso directo al JWT.

JwtInterceptor:
- Usa el "withCredentials: true" para que automáticamente envíe la cookie de sesión en cada request.
- Maneja errores 401.

AuthService:
- Ya no depende del token guardado.
- Se controla el estado de autenticación solo con el "BehaviorSubject<boolean>".
- El método "logout()" solo actualiza el estado y se redirige al login. 