### PR TITLE
Directiva de validación de errores de formularios (Issue #24)

### DIFF
--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -31,16 +31,12 @@
           formControlName="email"
           class="w-full p-3 rounded bg-gray-900 text-white border-none focus:ring-2 focus:ring-cyan-400"
         />
-
-        <small class="p-error"
-          *ngIf="loginFormPresenter.email?.touched && loginFormPresenter.email?.errors?.['required']">
-          El email es requerido
+        <small
+          class="p-error"
+          dictaErrorForm
+          [control]="loginFormPresenter.email">
         </small>
-
-        <small class="p-error"
-          *ngIf="loginFormPresenter.email?.touched && loginFormPresenter.email?.errors?.['email']">
-          El email no es válido
-        </small>
+        
       </div>
       <div class="mb-4">
         <label for="password1" class="block text-gray-300 font-medium mb-1">Contraseña</label>
@@ -52,19 +48,10 @@
           formControlName="password"
           class="w-full p-3 rounded bg-gray-900 text-white border-none focus:ring-2 focus:ring-cyan-400"
         />
-
-        <small class="p-error"
-          *ngIf="
-            loginFormPresenter.password?.touched && 
-            loginFormPresenter.password?.errors?.['required']">
-          La contraseña es requerida
-        </small>
-
-        <small class="p-error"
-          *ngIf="
-            loginFormPresenter.password?.touched && 
-            loginFormPresenter.password?.errors?.['minlength']">
-          La contraseña debe tener mínimo 8 caracteres
+        <small
+          class="p-error"
+          dictaErrorForm
+          [control]="loginFormPresenter.password">
         </small>
       </div>
 

--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -34,7 +34,7 @@
         <small
           class="p-error"
           dictaErrorForm
-          [control]="loginFormPresenter.email">
+          [control]="loginFormPresenter.Form.get('email')">
         </small>
         
       </div>
@@ -51,7 +51,7 @@
         <small
           class="p-error"
           dictaErrorForm
-          [control]="loginFormPresenter.password">
+          [control]="loginFormPresenter.Form.get('password')">
         </small>
       </div>
 

--- a/src/app/pages/auth/login/login.module.ts
+++ b/src/app/pages/auth/login/login.module.ts
@@ -2,12 +2,14 @@ import { NgModule } from '@angular/core';
 import { LoginRoutingModule } from './login-routing.module';
 import { LoginComponent } from './login.component';
 import { AuthThemeModule } from 'src/app/core/themes/auth/auth-primeng.module';
+import { SharedDirectiveModule } from "src/app/shared/directive/shared-directive.module";
 
 @NgModule({
   declarations: [LoginComponent],
   imports: [
     LoginRoutingModule,
-    AuthThemeModule
-  ]
+    AuthThemeModule,
+    SharedDirectiveModule
+]
 })
 export class LoginModule { }

--- a/src/app/pages/auth/register/register.component.html
+++ b/src/app/pages/auth/register/register.component.html
@@ -28,6 +28,11 @@
           class="register-input w-full"
           placeholder="Ingresa tu usuario"
         />
+        <small
+          class="p-error"
+          dictaErrorForm
+          [control]="registerFormPresenter.username">
+        </small>
       </div>
 
       <div class="field mb-3">
@@ -40,6 +45,11 @@
           class="register-input w-full"
           placeholder="Ingresa tu correo"
         />
+        <small
+          class="p-error"
+          dictaErrorForm
+          [control]="registerFormPresenter.email">
+        </small>
       </div>
 
       <div class="field mb-3">
@@ -53,13 +63,9 @@
           placeholder="Ingresa tu contraseña"
         ></p-password>
         <small
-        class="p-error"
-        *ngIf="
-          registerFormPresenter.Form.errors?.['weakPassword'] &&
-          registerFormPresenter.Form.get('password')?.touched
-        "
-        >
-        La contraseña debe tener mayúscula, minúscula, número y símbolo (mínimo 8 caracteres)
+          class="p-error"
+          dictaErrorForm
+          [control]="registerFormPresenter.Form.get('password')">
         </small>
       </div>
 
@@ -74,14 +80,9 @@
           placeholder="Confirma tu contraseña"
         ></p-password>
         <small
-        class="p-error"
-        *ngIf="
-          registerFormPresenter.Form.errors?.['passwordMismatch'] &&
-          (registerFormPresenter.Form.get('confirmPassword')?.dirty ||
-          registerFormPresenter.Form.get('confirmPassword')?.touched)
-        "
-        >
-        Las contraseñas no coinciden
+          class="p-error"
+          dictaErrorForm
+          [control]="registerFormPresenter.Form.get('confirmPassword')">
         </small>
       </div>
 

--- a/src/app/pages/auth/register/register.module.ts
+++ b/src/app/pages/auth/register/register.module.ts
@@ -2,12 +2,14 @@ import { NgModule } from '@angular/core';
 import { RegisterRoutingModule } from './register-routing.module';
 import { RegisterComponent } from './register.component';
 import { AuthThemeModule } from 'src/app/core/themes/auth/auth-primeng.module';
+import { SharedDirectiveModule } from "src/app/shared/directive/shared-directive.module";
 
 @NgModule({
   declarations: [RegisterComponent],
   imports: [
     RegisterRoutingModule,
     AuthThemeModule,
+    SharedDirectiveModule,
   ],
 })
 export class RegisterModule {}

--- a/src/app/shared/components/nav-bar/nav-bar.component.html
+++ b/src/app/shared/components/nav-bar/nav-bar.component.html
@@ -118,7 +118,7 @@
         <button
           class="px-4 py-1 rounded font-semibold text-black mx-3 lg:my-1 my-4 shadow-[0_4px_0_0_black] hover:shadow-[0_0_10px_2px_#F7C50F] hover:translate-y-0.5 hover:border-yellow-500 hover:border-[0px] bg-yellow-500 hover:bg-[#191919] hover:text-black transition duration-300"
           routerLink="/auth/login"
-          *ngIf="(auth.isLoggedIn$ | async)"
+          *ngIf="!(auth.isLoggedIn$ | async)"
         >
           Login
         </button>

--- a/src/app/shared/directive/error-form/error-form-directive.ts
+++ b/src/app/shared/directive/error-form/error-form-directive.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, ElementRef, OnInit } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
+import { Password } from 'primeng/password';
 
 @Directive({
   selector: '[dictaErrorForm]'
@@ -13,7 +14,7 @@ export class ErrorFormDirective implements OnInit {
   private errorMessages: Record<string, string> = {
     required: 'Este campo es obligatorio',
     email: 'Correo inválido',
-    minlength: 'Debe tener al menos 3 caracteres',
+    minlength: 'Debe tener al menos 8 caracteres',
     weakPassword: 'La contraseña debe tener mayúscula, minúscula, número y símbolo',
     passwordMismatch: 'Las contraseñas no coinciden'
   };

--- a/src/app/shared/directive/error-form/error-form-directive.ts
+++ b/src/app/shared/directive/error-form/error-form-directive.ts
@@ -36,9 +36,18 @@ export class ErrorFormDirective implements OnInit {
 
     if (this.control.touched && this.control.invalid) {
       const errors = this.control.errors;
-      if (!errors) return;
+    
+    if (!errors) return;
+
+    if (errors['minlength']) {
+      const requiredLength = errors['minlength'].requiredLength;
+      this.el.nativeElement.innerText =
+        `Debe tener al menos ${requiredLength} caracteres`;
+      return;
+    }
       const firstError = Object.keys(errors)[0];
       const message = this.errorMessages[firstError];
+
       this.el.nativeElement.innerText = message || '';
     } 
     else {

--- a/src/app/shared/directive/error-form/error-form-directive.ts
+++ b/src/app/shared/directive/error-form/error-form-directive.ts
@@ -1,0 +1,47 @@
+import { Directive, Input, ElementRef, OnInit } from '@angular/core';
+import { AbstractControl } from '@angular/forms';
+
+@Directive({
+  selector: '[dictaErrorForm]'
+})
+export class ErrorFormDirective implements OnInit {
+
+  @Input() control!: AbstractControl | null;
+
+  constructor(private el: ElementRef,) {}
+
+  private errorMessages: Record<string, string> = {
+    required: 'Este campo es obligatorio',
+    email: 'Correo inválido',
+    minlength: 'Debe tener al menos 3 caracteres',
+    weakPassword: 'La contraseña debe tener mayúscula, minúscula, número y símbolo',
+    passwordMismatch: 'Las contraseñas no coinciden'
+  };
+
+  ngOnInit(): void {
+
+    if (!this.control) return;
+
+    this.control.statusChanges?.subscribe(() => {
+      this.updateError();
+    });
+
+    this.updateError();
+  }
+
+  private updateError(): void {
+
+    if (!this.control) return;
+
+    if (this.control.touched && this.control.invalid) {
+      const errors = this.control.errors;
+      if (!errors) return;
+      const firstError = Object.keys(errors)[0];
+      const message = this.errorMessages[firstError];
+      this.el.nativeElement.innerText = message || '';
+    } 
+    else {
+      this.el.nativeElement.innerText = '';
+    }
+  }
+}

--- a/src/app/shared/directive/shared-directive.module.ts
+++ b/src/app/shared/directive/shared-directive.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { ActivoInactivoDirective } from './activo-inactivo/activo-inactivo.directive';
 import { BooleanStatusDirective } from './activo-inactivo/boolean-status.directive';
+import { ErrorFormDirective } from './error-form/error-form-directive';
 
 @NgModule({
-  declarations: [ActivoInactivoDirective, BooleanStatusDirective],
-  exports: [ActivoInactivoDirective, BooleanStatusDirective],
+  declarations: [ActivoInactivoDirective, BooleanStatusDirective, ErrorFormDirective],
+  exports: [ActivoInactivoDirective, BooleanStatusDirective, ErrorFormDirective],
 })
 export class SharedDirectiveModule {}


### PR DESCRIPTION
Implementación de la directiva reutilizable ErrorFormDirective para la gestión centralizada de errores en formularios reactivos.

Cambios principales:
- Se creó la directiva ErrorFormDirective para detectar el estado touched e invalid de los controles y mostrar mensajes de error personalizados según el tipo de validación.
- Se implementó la directiva en los formularios de login y register.
- Se registró la directiva en share-directive.module dentro de la carpeta directives.